### PR TITLE
propose adding a filter to handle cases where single topics may be embedded

### DIFF
--- a/bbpress-ajax-replies.php
+++ b/bbpress-ajax-replies.php
@@ -42,14 +42,14 @@ class bbPress_Ajax_Replies {
 	}
 
 	public function enqueue_scripts() {
-		if ( bbp_is_single_topic() ) {
+		if ( bbp_is_single_topic() || apply_filters('is_embedded_single_topic',false)) {
 			wp_enqueue_script( 'bbpress-reply-ajax', $this->url . 'reply-ajax.js', array( 'bbpress-topic', 'bbpress-reply', 'jquery', 'jquery-color' ) );
 		}
 	}
 
 	public function localize_reply_ajax_script() {
 		// Bail if not viewing a single topic
-		if ( ! bbp_is_single_topic() )
+		if ( ! (bbp_is_single_topic() || apply_filters('is_embedded_single_topic',false) ) )
 			return;
 
 		ob_start();


### PR DESCRIPTION
In my case, I'm building a learning site that integrates WooThemes Sensei with bbPress. I have written a separate plugin that allows me to associate a Sensei Lesson with a specific bbPress topic and then display that topic at the bottom of the Sensei Lesson page. This way, the learner who is being asked to engage in the course discussion on that topic can see the current state of the discussion and contribute a reply.

Without bbpress-ajax-replies, learners who do choose to add their reply to the discussion topic will be redirected away from the lesson page (which might even still be actively playing a media element) to the topic page. This will be confusing for the user who will suddenly feel lost and unsure how to navigate back to the lesson page.

bbpress-ajax-replies solves that problem by allowing the replies to be submitted via Ajax and updating the topic with the new reply—all without leaving the lesson page.

Here's the subsequent problem: bbpress-ajax-replies only loads itself via wp_enqueue_script() when bbp_is_single_topic() == true, but this method does not return true in my case and using a filter to make it true seems to have far more unintended side effects throughout bbPress's logic.

That's why I suggest adding this other option where bbpress-ajax-replies would also load itself if 
`true == apply_filters('is_embedded_single_topic',false)`

In my plugin, I can hook into that filter and add the rest of the logic necessary (such as making sure that the dependencies for bbpress-ajax-replies are loaded).

All of this is working now in my codebase. Thanks for this gem of a plugin!
